### PR TITLE
Add automation script and CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for AIPAC Transparency Platform
+POSTGRES_DB=aipac
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+FEC_API_KEY=DEMO_KEY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: |
+          python -m pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg
+*.egg-info/
+dist/
+build/
+
+# Env files
+.env
+.env.local
+
+# Data
+/data/raw/
+/data/processed/
+
+# Logs
+logs/
+
+# Node
+node_modules/
+
+# Others
+*.sqlite
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ This repository hosts the code and data for the AIPAC Transparency Platform. It 
 /tests/                - Unit and integration tests
 ```
 
+## Setup
+
+1. Copy `.env.example` to `.env` and add your API keys.
+2. Install dependencies and run tests:
+
+```bash
+python -m pip install -r requirements.txt
+pytest -v
+```
+
 Use `docker compose up --build -d` to start all services.
+
+The `automation/fetch_aipac_donations.py` script downloads AIPAC PAC disbursements from the FEC API and saves them under `data/raw/`.
 
 See `AGENTS.md` for full project guidelines.

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,10 @@
+# Automation
+
+This folder contains data agent scripts and scheduling utilities. The main agent
+provided is `fetch_aipac_donations.py`, which downloads AIPAC PAC disbursements
+to congressional candidates from the FEC API.
+
+## Scheduled Runs
+
+Use GitHub Actions or cron on your server to execute the agents regularly. The
+included CI workflow runs unit tests on every push or pull request.

--- a/automation/fetch_aipac_donations.py
+++ b/automation/fetch_aipac_donations.py
@@ -1,0 +1,79 @@
+"""Fetch AIPAC PAC donations to congressional candidates from the FEC API."""
+
+import csv
+import os
+import requests
+from datetime import datetime
+from typing import Iterator, Dict
+
+FEC_ENDPOINT = "https://api.open.fec.gov/v1/schedules/schedule_b/"
+COMMITTEE_ID = "C00797670"  # AIPAC PAC
+
+
+class FECClient:
+    """Simple client for the FEC API."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def fetch_disbursements(self, cycle: int) -> Iterator[Dict[str, str]]:
+        """Yield disbursements for the given cycle."""
+        page = 1
+        params = {
+            "api_key": self.api_key,
+            "committee_id": COMMITTEE_ID,
+            "two_year_transaction_period": cycle,
+            "per_page": 100,
+        }
+        while True:
+            params["page"] = page
+            resp = requests.get(FEC_ENDPOINT, params=params, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            for item in data.get("results", []):
+                yield {
+                    "recipient_committee_name": item.get("recipient_committee_name"),
+                    "recipient_name": item.get("recipient_name"),
+                    "disbursement_date": item.get("disbursement_date"),
+                    "disbursement_amount": item.get("disbursement_amount"),
+                }
+            pagination = data.get("pagination", {})
+            if page >= pagination.get("pages", 0):
+                break
+            page += 1
+
+
+def save_to_csv(records: Iterator[Dict[str, str]], path: str) -> None:
+    """Save disbursement records to CSV."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "recipient_committee_name",
+                "recipient_name",
+                "disbursement_date",
+                "disbursement_amount",
+            ],
+        )
+        writer.writeheader()
+        for row in records:
+            writer.writerow(row)
+
+
+def main() -> None:
+    api_key = os.environ.get("FEC_API_KEY")
+    if not api_key:
+        raise SystemExit("FEC_API_KEY environment variable not set")
+    cycle = 2022
+    client = FECClient(api_key)
+    records = client.fetch_disbursements(cycle)
+    output_dir = os.path.join("data", "raw")
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    output_path = os.path.join(output_dir, f"aipac_donations_{cycle}_{timestamp}.csv")
+    save_to_csv(records, output_path)
+    print(f"Saved data to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pytest

--- a/tests/test_fetch_donations.py
+++ b/tests/test_fetch_donations.py
@@ -1,0 +1,47 @@
+import builtins
+from automation.fetch_aipac_donations import FECClient, save_to_csv
+from unittest import mock
+import io
+
+
+def test_fetch_disbursements_pagination(monkeypatch):
+    responses = [
+        {
+            "results": [{"recipient_name": "A", "disbursement_amount": 1}],
+            "pagination": {"page": 1, "pages": 2},
+        },
+        {
+            "results": [{"recipient_name": "B", "disbursement_amount": 2}],
+            "pagination": {"page": 2, "pages": 2},
+        },
+    ]
+
+    def fake_get(url, params=None, timeout=None):
+        index = params.get("page") - 1
+        response = mock.Mock()
+        response.json.return_value = responses[index]
+        response.raise_for_status.return_value = None
+        return response
+
+    monkeypatch.setattr("requests.get", fake_get)
+    client = FECClient("TEST")
+    records = list(client.fetch_disbursements(2022))
+    assert len(records) == 2
+    assert records[0]["recipient_name"] == "A"
+    assert records[1]["recipient_name"] == "B"
+
+
+def test_save_to_csv(tmp_path):
+    data = [
+        {
+            "recipient_committee_name": "COM",
+            "recipient_name": "A",
+            "disbursement_date": "2022-01-01",
+            "disbursement_amount": 10,
+        }
+    ]
+    path = tmp_path / "out.csv"
+    save_to_csv(iter(data), path)
+    text = path.read_text()
+    assert "recipient_name" in text
+    assert "A" in text


### PR DESCRIPTION
## Summary
- add example `.env` template and `.gitignore`
- implement data fetching agent for AIPAC PAC disbursements
- provide unit tests and CI workflow
- update project README and automation instructions

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859c194bbcc832dad6f8b8942f13002