### PR TITLE
Initialize basic backend and frontend

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"message": "AIPAC API"}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/automation/fetch_aipac_donations.py
+++ b/automation/fetch_aipac_donations.py
@@ -70,7 +70,10 @@ def main() -> None:
     output_dir = os.path.join("data", "raw")
     os.makedirs(output_dir, exist_ok=True)
     timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
-    output_path = os.path.join(output_dir, f"aipac_donations_{cycle}_{timestamp}.csv")
+    output_path = os.path.join(
+        output_dir,
+        f"aipac_donations_{cycle}_{timestamp}.csv",
+    )
     save_to_csv(records, output_path)
     print(f"Saved data to {output_path}")
 

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+EXPOSE 3000
+CMD ["python", "-m", "http.server", "3000", "--bind", "0.0.0.0"]

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>AIPAC Transparency</title>
+</head>
+<body>
+    <h1>AIPAC Transparency Platform</h1>
+    <p>Frontend placeholder</p>
+</body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for module imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_fetch_donations.py
+++ b/tests/test_fetch_donations.py
@@ -1,7 +1,5 @@
-import builtins
 from automation.fetch_aipac_donations import FECClient, save_to_csv
 from unittest import mock
-import io
 
 
 def test_fetch_disbursements_pagination(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure tests can import project modules by adjusting `sys.path`
- fix lint errors in automation script and tests
- add minimal FastAPI backend and static site frontend with Dockerfiles

## Testing
- `flake8 automation tests`
- `black automation tests`
- `pytest -q`
- `docker compose build frontend api` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685a46132754832d9514e61ccc021144